### PR TITLE
Add better assertions for failing verifiable credential test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     "chai": "^4.1.2",
     "core-js": "^3.0.1",
     "crypto-ld": "^3.0.0",
+    "eslint": "^5.16.0",
+    "eslint-config-digitalbazaar": "^2.0.0",
+    "eslint-plugin-jsdoc": "^4.8.3",
     "karma": "^4.1.0",
     "karma-babel-preprocessor": "^8.0.0",
     "karma-chai": "^0.1.0",
@@ -70,11 +73,9 @@
     "karma-webpack": "^3.0.5",
     "mocha": "^6.1.2",
     "regenerator-runtime": "^0.13.1",
-    "eslint": "^5.16.0",
-    "eslint-config-digitalbazaar": "^2.0.0",
-    "eslint-plugin-jsdoc": "^4.8.3",
     "uuid": "^3.3.2",
     "webpack": "^4.29.6",
+    "webpack-cli": "^3.3.2",
     "webpack-merge": "^4.1.0"
   },
   "engines": {

--- a/tests/10-verify.spec.js
+++ b/tests/10-verify.spec.js
@@ -47,10 +47,10 @@ async function documentLoader(url) {
       document: context
     };
   }
-  throw new Error(`${url} is not an authorized supported context url.`)
+  throw new Error(`${url} is not an authorized supported context url.`);
 }
 
-const assertionController  = {
+const assertionController = {
   '@context': 'https://w3id.org/security/v2',
   id: 'https://example.com/i/carol',
   assertionMethod: [
@@ -73,7 +73,7 @@ const credential = {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "alumniOf": "<span lang='en'>Example University</span>"
   }
-}
+};
 
 before(async () => {
   // Set up the key that will be signing and verifying
@@ -93,19 +93,23 @@ before(async () => {
   suite = new jsigs.suites.Ed25519Signature2018({
     verificationMethod: 'https://example.edu/issuers/keys/1',
     key: keyPair
-  })
+  });
 });
 
 describe('issue()', () => {
   it('should issue a verifiable credential with proof', async () => {
     verifiedCredential = await vc.issue({credential, suite});
-    verifiedCredential.proof.should.exist;
+    verifiedCredential.should.exist;
+    verifiedCredential.should.be.an('object');
+    verifiedCredential.should.have.property('proof');
+    verifiedCredential.proof.should.be.an('object');
   });
 });
 
 describe('verify()', () => {
   it('should verify a vc', async () => {
-    const result = await vc.verify({credential: verifiedCredential, suite, documentLoader});
+    const result = await vc.verify(
+      {credential: verifiedCredential, suite, documentLoader});
     // console.log(JSON.stringify(result, null, 2))
     result.verified.should.be.true;
     expect(result.error).to.not.exist;


### PR DESCRIPTION
This doesn't do much it just generates a better error message than the last test.

p.s. did you know chai expect allows custom error messages? can't seem to find them for should. Anyways, this means a failing test on travis actually returns an informative error instead of

```js
     TypeError: Cannot read property 'should' of undefined
```

is now

```
1) issue()
       should issue a verifiable credential with proof:
     AssertionError: expected { Object (@context, id, ...) } to have property 'proof'
      at Context.property (tests/10-verify.spec.js:104:36)
```