### PR TITLE
Add `json` extension to require.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dist/*.js.map",
     "dist/node6/**/*.js",
     "lib/*.js",
-    "lib/contexts/*.js"
+    "lib/contexts"
   ],
   "dependencies": {
     "commander": "^2.8.0",


### PR DESCRIPTION
I'm attempting to use this module as a dependency elsewhere and the changed line here fails with Node 10.x.