### PR TITLE
Update to RFC3999 dateRegex.

### DIFF
--- a/lib/vc.js
+++ b/lib/vc.js
@@ -42,6 +42,14 @@ const CredentialIssuancePurpose = require('./CredentialIssuancePurpose');
 const defaultDocumentLoader = jsigs.extendContextLoader(
   require('./documentLoader'));
 
+// Z and T can be lowercase
+// RFC3999 regex
+const dateRegex = new RegExp('^(?<fullyear>\\d{4})-(?<month>0[1-9]|1[0-2])-' +
+    '(?<mday>0[1-9]|[12][0-9]|3[01])T(?<hour>[01][0-9]|2[0-3]):' +
+    '(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)' +
+    '(?<secfrac>\\.[0-9]+)?(Z|(\\+|-)(?<offset_hour>[01][0-9]|2[0-3]):' +
+    '(?<offset_minute>[0-5][0-9]))$', 'i');
+
 module.exports = {
   issue,
   verify,
@@ -50,7 +58,8 @@ module.exports = {
   // export for testing:
   _checkCredential,
   _checkPresentation,
-  _verifyPresentation
+  _verifyPresentation,
+  dateRegex
 };
 
 /**
@@ -385,8 +394,6 @@ function _checkCredential(credential) {
   if(jsonld.getValues(credential, 'issuanceDate').length > 1) {
     throw new Error('"issuanceDate" property can only have one value.');
   }
-
-  const dateRegex = new RegExp(/^(?<fullyear>\d{4})-(?<month>0[1-9]|1[0-2])-(?<mday>0[1-9]|[12][0-9]|3[01])T(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?(Z|(\+|-)(?<offset_hour>[01][0-9]|2[0-3]):(?<offset_minute>[0-5][0-9]))$/);
 
   // check issued is a date
   if(!credential['issuanceDate']) {

--- a/tests/10-verify.spec.js
+++ b/tests/10-verify.spec.js
@@ -116,6 +116,17 @@ describe('verify()', () => {
   });
 });
 
+describe('verifies RFC3999 Dates', function() {
+  it('verify a valid date', function() {
+    const latest = new Date().toISOString();
+    vc.dateRegex.test(latest).should.be.true;
+  });
+  it('should not verify an invalid date', function() {
+    const invalid = '2017/09/27';
+    vc.dateRegex.test(invalid).should.be.false;
+  });
+});
+
 describe.skip('verify API', () => {
   it('verifies a valid presentation', async () => {
     const challenge = uuid();

--- a/tests/10-verify.spec.js
+++ b/tests/10-verify.spec.js
@@ -121,6 +121,11 @@ describe('verifies RFC3999 Dates', function() {
     const latest = new Date().toISOString();
     vc.dateRegex.test(latest).should.be.true;
   });
+  it('verify a valid date with lowercase t', function() {
+    const latest = new Date().toISOString().toLowerCase();
+    vc.dateRegex.test(latest).should.be.true;
+  });
+
   it('should not verify an invalid date', function() {
     const invalid = '2017/09/27';
     vc.dateRegex.test(invalid).should.be.false;


### PR DESCRIPTION
https://tools.ietf.org/html/rfc3339

```
date-fullyear   = 4DIGIT
   date-month      = 2DIGIT  ; 01-12
   date-mday       = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on
                             ; month/year
   time-hour       = 2DIGIT  ; 00-23
   time-minute     = 2DIGIT  ; 00-59
   time-second     = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second
                             ; rules
   time-secfrac    = "." 1*DIGIT
   time-numoffset  = ("+" / "-") time-hour ":" time-minute
   time-offset     = "Z" / time-numoffset

   partial-time    = time-hour ":" time-minute ":" time-second
                     [time-secfrac]
   full-date       = date-fullyear "-" date-month "-" date-mday
   full-time       = partial-time time-offset

   date-time       = full-date "T" full-time
```

all RFC3999 means is ISO8601, but with 4 digit years (zero pad) and 2 digit months and days (also zero pad) so existing regex was pretty much ok except the Z and T can be lowercase.
I also added some basic tests to the unit test project.