### PR TITLE
Remove Node.js v6 support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # vc-js ChangeLog
 
+### Removed
+- Node.js v6 support.
+
 ## 0.2.0 - 2019-08-07
 
 ### Added
-- Export `defaultDocumentLoader` in main vc.js 
+- Export `defaultDocumentLoader` in main vc.js
 
 ## 0.1.0 - 2019-08-07
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,8 +5,4 @@
  *
  * Copyright 2017 Digital Bazaar, Inc.
  */
-if(require('semver').gte(process.version, '8.0.0')) {
-  module.exports = require('./vc');
-} else {
-  module.exports = require('../dist/node6/lib/vc');
-}
+module.exports = require('./vc.js');

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "bin/vc-js",
     "dist/*.js",
     "dist/*.js.map",
-    "dist/node6/**/*.js",
     "lib/*.js",
     "lib/contexts"
   ],
@@ -41,7 +40,6 @@
     "get-stdin": "^6.0.0",
     "jsonld": "^1.6.2",
     "jsonld-signatures": "^4.1.2",
-    "semver": "^6.0.0",
     "supports-color": "^6.1.0"
   },
   "devDependencies": {
@@ -92,9 +90,7 @@
   ],
   "scripts": {
     "no-prepublish": "npm run build",
-    "no-build": "npm run build-webpack && npm run build-node6",
-    "no-build-webpack": "webpack",
-    "no-build-node6": "babel --no-babelrc --out-dir dist/node6 --presets=node6-es6 lib/*.js",
+    "no-build": "webpack",
     "fetch-test-suites": "npm run fetch-vc-test-suite",
     "fetch-vc-test-suite": "if [ ! -e test-suites/vc-test-suite ]; then git clone --depth 1 https://github.com/digitalbazaar/vc-test-suite.git test-suites/vc-test-suite; fi",
     "test": "bin/vc-test",


### PR DESCRIPTION
- No longer supporting node6. The build was disabled forever ago.
- Leaving the index.js -> vc.js part for future conversion to use `esm`.