### PR TITLE
Await jsigs.verify for presentations.

### DIFF
--- a/lib/vc.js
+++ b/lib/vc.js
@@ -301,7 +301,7 @@ async function _verifyPresentation(options = {}) {
     challenge
   });
 
-  const presentationResult = jsigs.verify(
+  const presentationResult = await jsigs.verify(
     presentation, {purpose, documentLoader, ...options});
 
   return {


### PR DESCRIPTION
Important: verify Presentations are broken.

thankfully it's a simple fix: we just forward to `await jsigs.verify` for presentations.

https://github.com/digitalbazaar/jsonld-signatures/blob/f1e78c2674a786c3cdc8d310dbf228ed8a1e1b8e/lib/jsonld-signatures.js#L35-L51

