### PR TITLE
Issue 45 greedy type error

### DIFF
--- a/lib/vc.js
+++ b/lib/vc.js
@@ -97,7 +97,7 @@ async function issue(options = {}) {
   // check to make sure the `suite` has required params
   // Note: verificationMethod defaults to publicKey.id, in suite constructor
   if(!suite || !suite.verificationMethod) {
-    throw new TypeError('"suite.verificationMethod" property is required.')
+    throw new TypeError('"suite.verificationMethod" property is required.');
   }
 
   // run common credential checks
@@ -141,7 +141,8 @@ async function issue(options = {}) {
  *   case of presentations).
  * @param {function} [options.documentLoader]
  *
- * @returns {Promise<{verified: boolean, results: *[], error: Error}>}
+ * @returns {Promise<{verified: boolean, results: *[], error: Error}>} If
+ *   verified is false verification failed.
  */
 async function verify(options = {}) {
   const {credential, presentation} = options;
@@ -177,7 +178,8 @@ async function verify(options = {}) {
  * @param {CredentialIssuancePurpose} [options.purpose]
  * @param {Function} [options.documentLoader]
  *
- * @returns {Promise<{verified: boolean, results: *[], error: Error}>}
+ * @returns {Promise<{verified: boolean, results: *[], error: Error}>} If
+ *   verified is false the credential could not be verified.
  */
 async function _verifyCredential(options = {}) {
   const {credential} = options;
@@ -220,7 +222,8 @@ async function _verifyCredential(options = {}) {
  * @throws {Error} If the credential (or the presentation params) are missing
  *   required properties.
  *
- * @returns {Presentation}
+ * @returns {Presentation} The credential wrapped inside of a
+ *   VerifiablePresentation.
  */
 function createPresentation({verifiableCredential, id, holder} = {}) {
   if(!verifiableCredential) {
@@ -264,7 +267,8 @@ function createPresentation({verifiableCredential, id, holder} = {}) {
  *
  * @param {function} [options.documentLoader]
  *
- * @returns {Promise<{VerifiablePresentation}>}
+ * @returns {Promise<{VerifiablePresentation}>} A VerifiablePresentation with
+ *   a proof.
  */
 async function signPresentation(options = {}) {
   const {presentation, domain, challenge} = options;
@@ -306,7 +310,8 @@ async function signPresentation(options = {}) {
  *
  * @throws {Error} If presentation is missing required params.
  *
- * @returns {Promise<{verified: boolean, results: *[], error: Error}>}
+ * @returns {Promise<{verified: boolean, results: *[], error: Error}>} If
+ *   verified is false the presentation could not be verified.
  */
 async function _verifyPresentation(options = {}) {
   const {presentation, unsignedPresentation} = options;
@@ -325,7 +330,7 @@ async function _verifyPresentation(options = {}) {
   const allCredentialsVerified = vcResult.every(r => r.verified);
 
   if(!allCredentialsVerified) {
-    return {verified: false, error: vcResult.map(r => r.error).flat()}
+    return {verified: false, error: vcResult.map(r => r.error).flat()};
   }
 
   if(unsignedPresentation) {
@@ -353,9 +358,11 @@ async function _verifyPresentation(options = {}) {
 }
 
 /**
- * @param {String|object} obj
- * @returns {String|undefined}
+ * @param {string|object} obj - Either an object with an id property
+ *   or a string that is an id.
+ * @returns {string|undefined} Either an id or undefined.
  * @private
+ *
  */
 function _getId(obj) {
   if(typeof obj === 'string') {
@@ -370,7 +377,7 @@ function _getId(obj) {
 }
 
 /**
- * @param presentation
+ * @param {object} presentation - An object that could be a presentation.
  * @throws {Error}
  * @private
  */
@@ -395,7 +402,7 @@ function _checkPresentation(presentation) {
 }
 
 /**
- * @param credential
+ * @param {object} credential - An object that could be a VerifiableCredential.
  * @throws {Error}
  * @private
  */

--- a/lib/vc.js
+++ b/lib/vc.js
@@ -400,12 +400,6 @@ function _checkPresentation(presentation) {
  * @private
  */
 function _checkCredential(credential) {
-  // check context cardinality
-  if(jsonld.getValues(credential, '@context').length < 2) {
-    throw new Error(
-      '"@context" property needs to be an array of two or more contexts.');
-  }
-
   // ensure first context is 'https://www.w3.org/2018/credentials/v1'
   if(credential['@context'][0] !== 'https://www.w3.org/2018/credentials/v1') {
     throw new Error(

--- a/lib/vc.js
+++ b/lib/vc.js
@@ -419,10 +419,9 @@ function _checkCredential(credential) {
   }
 
   if(!Array.isArray(credential['type']) ||
-      credential['type'].length < 2 ||
       !credential['type'].includes('VerifiableCredential')) {
     throw new Error(
-      '"type" must be `VerifiableCredential` plus specific type.');
+      '"type" must include `VerifiableCredential`.');
   }
 
   if(!credential['credentialSubject']) {


### PR DESCRIPTION
Fix for issue: https://github.com/digitalbazaar/vc-js/issues/45

This allows the following:

1. VerifiableCredentials with only one type `VerifiableCredential`
2. VerifiableCredentials with only one `@context` `https://www.w3.org/2018/credentials/v1`

Previously we were throwing when a VC only had one type or one `@context`

@lemoustachiste feel free to add yourself a reviewer and I hope this branch helps.