### PR TITLE
Support a non-array type attribute for VCs.

### DIFF
--- a/lib/vc.js
+++ b/lib/vc.js
@@ -419,10 +419,8 @@ function _checkCredential(credential) {
     throw new Error('"type" property is required.');
   }
 
-  if(!Array.isArray(credential['type']) ||
-      !credential['type'].includes('VerifiableCredential')) {
-    throw new Error(
-      '"type" must include `VerifiableCredential`.');
+  if(!jsonld.getValues(credential, 'type').includes('VerifiableCredential')) {
+    throw new Error('"type" must include `VerifiableCredential`.');
   }
 
   if(!credential['credentialSubject']) {


### PR DESCRIPTION
Ensure credentials can have a type property that is either a single string or an array.