### PR TITLE
Change return value of verify API.

### DIFF
--- a/lib/vc.js
+++ b/lib/vc.js
@@ -364,8 +364,10 @@ async function _verifyPresentation(options = {}) {
     const allCredentialsVerified = credentialResults.every(r => r.verified);
 
     if(!allCredentialsVerified) {
+      // TODO: use Array.flat() when it is supported in all LTS platforms
+      const _flattened = arr => [].concat(...arr);
       return {
-        error: credentialResults.map(r => r.error).flat(),
+        error: _flattened(credentialResults.map(r => r.error)),
         verified: false,
       };
     }

--- a/lib/vc.js
+++ b/lib/vc.js
@@ -353,18 +353,21 @@ async function _verifyPresentation(options = {}) {
   const documentLoader = options.documentLoader || defaultDocumentLoader;
 
   // if verifiableCredentials are present, verify them, individually
-  let vcResult;
+  let credentialResults;
   const credentials = jsonld.getValues(presentation, 'verifiableCredential');
   if(credentials.length > 0) {
     // verify every credential in `verifiableCredential`
-    vcResult = await Promise.all(credentials.map(credential => {
+    credentialResults = await Promise.all(credentials.map(credential => {
       return verifyCredential({credential, documentLoader, ...options});
     }));
 
-    const allCredentialsVerified = vcResult.every(r => r.verified);
+    const allCredentialsVerified = credentialResults.every(r => r.verified);
 
     if(!allCredentialsVerified) {
-      return {verified: false, error: vcResult.map(r => r.error).flat()};
+      return {
+        error: credentialResults.map(r => r.error).flat(),
+        verified: false,
+      };
     }
   }
 
@@ -386,8 +389,9 @@ async function _verifyPresentation(options = {}) {
     presentation, {purpose, documentLoader, ...options});
 
   return {
+    presentationResult,
     verified: presentationResult.verified,
-    results: [].concat([presentationResult, vcResult]),
+    credentialResults,
     error: presentationResult.error
   };
 }


### PR DESCRIPTION
The current `verify` implementation returns an array that contains:
- an object that has the presentation result
- and an array that contains the credentials results.

Example here: https://gist.github.com/mattcollier/ff5fd44b2f51f914c90b86a7588ea47b#file-gistfile1-txt-L51-L71

As a consumer of this API, there is no way to discern what is what. 

This patch makes it clear what the return values represent.

I think we should get this in before the next release because I believe the current implementation is broken.