### PR TITLE
Generate type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "mocha": "^7.0.0",
     "nyc": "^15.0.0",
     "regenerator-runtime": "^0.13.1",
+    "typescript": "^4.0.3",
     "uuid": "^3.4.0",
     "veres-one-context": "^11.0.0",
     "webpack": "^4.41.5",
@@ -101,7 +102,8 @@
     "Credential"
   ],
   "scripts": {
-    "prepublish": "npm run build",
+    "ts:defs": "npx tsc --declaration --outDir dist --emitDeclarationOnly",
+    "prepublish": "npm run build && npm run ts:defs",
     "build": "webpack",
     "fetch-test-suites": "npm run fetch-vc-test-suite",
     "fetch-vc-test-suite": "if [ ! -e test-suites/vc-test-suite ]; then git clone --depth 1 https://github.com/digitalbazaar/vc-test-suite.git test-suites/vc-test-suite; fi",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist"
+  },
+  "include": ["lib/**/*"],
+  "exclude": ["node_modules", "tests"]
+}


### PR DESCRIPTION
This seemed to be a minimally-invasive way for to get type definitions, as desired by typescript users. 

Notes: 

- Based on my searches, publishing to the same `dist` folder (that webpack minified files are published to) seemed the recommended way, but this is a dark art to me. I didn't want to risk destabilization by modifying the webpack build itself.
- `npm run prepublish` [output files uploaded here](https://github.com/digitalcredentials/vc-js-dist/tree/main/dist)


