### PR TITLE
Deleted incorrect description for verify command.

### DIFF
--- a/bin/vc-js
+++ b/bin/vc-js
@@ -199,7 +199,6 @@ program
   .command('verify')
   .alias('v')
   .description('verify a credential')
-  .description('issue a credential')
   .option('-i, --issuer <issuer>', 'The URL for the issuer public key.')
   .option('-p, --public-key <public-key>', 'The public key PEM file.')
   //.option('-o, --owner <owner>', 'The key owner URL.')


### PR DESCRIPTION
Deleted incorrect description for `verify` command.  So small I didn't test this extensively but it seemed like the right thing to do.