### PR TITLE
Reject a credentialSubject.id that is not a URI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @digitalbazaar/vc ChangeLog
 
+## 1.1.0 -
+
+### Changed
+- Fix validation of `credentialSubject.id`, `issuer` and `evidence` --
+  if it's not a URI, reject the credential.
+
 ## 1.0.0 - 2021-04-22
 
 ### Changed

--- a/lib/vc.js
+++ b/lib/vc.js
@@ -44,6 +44,7 @@ const defaultDocumentLoader = jsigs.extendContextLoader(
   require('./documentLoader'));
 const {constants: {CREDENTIALS_CONTEXT_V1_URL}} =
   require('credentials-context');
+const URI = require('uri-js');
 
 // Z and T can be lowercase
 // RFC3339 regex
@@ -514,6 +515,13 @@ function _checkCredential(credential) {
     throw new Error('"credentialSubject" property is required.');
   }
 
+  // If credentialSubject.id is present and is not a URI, reject it
+  if(credential.credentialSubject.id) {
+    _validateUriId({
+      id: credential.credentialSubject.id, propertyName: 'credentialSubject.id'
+    });
+  }
+
   if(!credential.issuer) {
     throw new Error('"issuer" property is required.');
   }
@@ -541,15 +549,12 @@ function _checkCredential(credential) {
   }
 
   // check issuer is a URL
-  // FIXME
   if('issuer' in credential) {
     const issuer = _getId(credential.issuer);
     if(!issuer) {
       throw new Error(`"issuer" id is required.`);
     }
-    if(!issuer.includes(':')) {
-      throw new Error(`"issuer" id must be a URL: ${issuer}`);
-    }
+    _validateUriId({id: issuer, propertyName: 'issuer'});
   }
 
   if('credentialStatus' in credential) {
@@ -562,11 +567,10 @@ function _checkCredential(credential) {
   }
 
   // check evidences are URLs
-  // FIXME
   jsonld.getValues(credential, 'evidence').forEach(evidence => {
     const evidenceId = _getId(evidence);
-    if(evidenceId && !evidenceId.includes(':')) {
-      throw new Error(`"evidence" id must be a URL: ${evidence}`);
+    if(evidenceId) {
+      _validateUriId({id: evidenceId, propertyName: 'evidence'});
     }
   });
 
@@ -575,5 +579,21 @@ function _checkCredential(credential) {
       !dateRegex.test(credential.expirationDate)) {
     throw new Error(
       `"expirationDate" must be a valid date: ${credential.expirationDate}`);
+  }
+}
+
+function _validateUriId({id, propertyName = 'id'}) {
+  let scheme;
+  let reference;
+  try {
+    ({scheme, reference} = URI.parse(id));
+  } catch(e) {
+    const error = new TypeError(`"${propertyName}" must be a URI: "${id}".`);
+    error.cause = e;
+    throw error;
+  }
+
+  if(!scheme || reference !== 'absolute') {
+    throw new TypeError(`"${propertyName}" must be a URI: "${id}".`);
   }
 }

--- a/lib/vc.js
+++ b/lib/vc.js
@@ -581,7 +581,7 @@ function _checkCredential(credential) {
   }
 }
 
-function _validateUriId({id, propertyName = 'id'}) {
+function _validateUriId({id, propertyName}) {
   let parsed;
   try {
     parsed = new URL(id);

--- a/lib/vc.js
+++ b/lib/vc.js
@@ -44,7 +44,6 @@ const defaultDocumentLoader = jsigs.extendContextLoader(
   require('./documentLoader'));
 const {constants: {CREDENTIALS_CONTEXT_V1_URL}} =
   require('credentials-context');
-const URI = require('uri-js');
 
 // Z and T can be lowercase
 // RFC3339 regex
@@ -583,17 +582,16 @@ function _checkCredential(credential) {
 }
 
 function _validateUriId({id, propertyName = 'id'}) {
-  let scheme;
-  let reference;
+  let parsed;
   try {
-    ({scheme, reference} = URI.parse(id));
+    parsed = new URL(id);
   } catch(e) {
     const error = new TypeError(`"${propertyName}" must be a URI: "${id}".`);
     error.cause = e;
     throw error;
   }
 
-  if(!scheme || reference !== 'absolute') {
+  if(!parsed.protocol) {
     throw new TypeError(`"${propertyName}" must be a URI: "${id}".`);
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "credentials-context": "^1.0.0",
+    "credentials-context": "^2.0.0",
     "jsonld": "^5.2.0",
-    "jsonld-signatures": "^9.0.2"
+    "jsonld-signatures": "^9.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.13.8",
@@ -38,13 +38,13 @@
     "@babel/preset-env": "^7.13.9",
     "@babel/runtime": "^7.13.9",
     "@digitalbazaar/ed25519-signature-2018": "^2.0.1",
-    "@digitalbazaar/ed25519-signature-2020": "^2.1.0",
-    "@digitalbazaar/ed25519-verification-key-2018": "^3.0.0",
-    "@digitalbazaar/ed25519-verification-key-2020": "^2.0.0",
+    "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
+    "@digitalbazaar/ed25519-verification-key-2018": "^3.1.1",
+    "@digitalbazaar/ed25519-verification-key-2020": "^3.1.0",
     "babel-loader": "^8.2.2",
     "chai": "^4.3.3",
     "cross-env": "^7.0.3",
-    "did-context": "^3.0.1",
+    "did-context": "^3.1.1",
     "did-veres-one": "^13.0.0",
     "eslint": "^7.21.0",
     "eslint-config-digitalbazaar": "^2.6.1",
@@ -61,7 +61,7 @@
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^15.1.0",
     "uuid": "^8.3.2",
-    "veres-one-context": "^11.0.0",
+    "veres-one-context": "^12.0.0",
     "webpack": "^5.24.3"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "credentials-context": "^2.0.0",
     "jsonld": "^5.2.0",
-    "jsonld-signatures": "^9.3.0"
+    "jsonld-signatures": "^9.3.0",
+    "uri-js": "^4.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.13.8",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "credentials-context": "^2.0.0",
     "jsonld": "^5.2.0",
-    "jsonld-signatures": "^9.3.0",
-    "uri-js": "^4.4.1"
+    "jsonld-signatures": "^9.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.13.8",

--- a/test/10-verify.spec.js
+++ b/test/10-verify.spec.js
@@ -409,6 +409,58 @@ describe('test for multiple credentials', async () => {
   }
 });
 
+describe('_checkCredential', () => {
+  it('should reject a credentialSubject.id that is not a URI', () => {
+    const credential = jsonld.clone(mockData.credentials.alpha);
+    credential.issuer = 'http://example.edu/credentials/58473';
+    credential.credentialSubject.id = '12345';
+    let error;
+    try {
+      vc._checkCredential(credential);
+    } catch(e) {
+      error = e;
+    }
+    should.exist(error,
+      'Should throw error when "credentialSubject.id" is not a URI');
+    error.should.be.instanceof(TypeError);
+    error.message.should
+      .contain('"credentialSubject.id" must be a URI');
+  });
+
+  it('should reject an issuer that is not a URI', () => {
+    const credential = jsonld.clone(mockData.credentials.alpha);
+    credential.issuer = '12345';
+    let error;
+    try {
+      vc._checkCredential(credential);
+    } catch(e) {
+      error = e;
+    }
+    should.exist(error,
+      'Should throw error when "credentialSubject.id" is not a URI');
+    error.should.be.instanceof(TypeError);
+    error.message.should
+      .contain('"issuer" must be a URI');
+  });
+
+  it('should reject an evidence id that is not a URI', () => {
+    const credential = jsonld.clone(mockData.credentials.alpha);
+    credential.issuer = 'did:example:12345';
+    credential.evidence = '12345';
+    let error;
+    try {
+      vc._checkCredential(credential);
+    } catch(e) {
+      error = e;
+    }
+    should.exist(error,
+      'Should throw error when "evidence" is not a URI');
+    error.should.be.instanceof(TypeError);
+    error.message.should
+      .contain('"evidence" must be a URI');
+  });
+});
+
 async function _generateCredential() {
   const mockCredential = jsonld.clone(mockData.credentials.alpha);
   const {didDocument, documentLoader} = await _loadDid();


### PR DESCRIPTION
Also reject `issuer` and `evidence` when they're not URIs.